### PR TITLE
Add The Swift Programming Language (5.9 beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Dive into Swift Macros with these WWDC sessions:
 - [Expand Swift Macros](https://developer.apple.com/videos/play/wwdc2023-10167): A deeper exploration into crafting your Macros and testing their functionality.
 - [Example Swift Macros](https://github.com/DougGregor/swift-macro-examples): Check out real-world examples from Apple, like `@AddCompletionHandler` and `@AddAsync`.
 
+### **The Swift Programming Language (5.9 beta):**
+- [Macros](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/macros): The Official Step-by-Step Guide to Using Macros for Compile-Time Code Generation in Swift.
+
 ### **Community Blogs**
 - [Swift Macros by SwiftLee](https://www.avanderlee.com/swift/macros/)
   - Antoine goes over the introduction of what Macros are and how you can build your own one with an example.

--- a/README.md
+++ b/README.md
@@ -15,16 +15,17 @@ A lot of use-cases my [Sourcery](https://github.com/krzysztofzablocki/Sourcery) 
 - [Swift AST Explorer](https://swift-ast-explorer.com/)
   - This is extremely helpful when working with [SwiftSyntax](https://github.com/apple/swift-syntax), I used this when writing [Sourcery](https://github.com/krzysztofzablocki/Sourcery) parser and you can leverage it to build your own Macros. 
 
-### **WWDC 2023:**
+### **Apple:**
 
 Dive into Swift Macros with these WWDC sessions:
 
 - [Write Swift Macros](https://developer.apple.com/videos/play/wwdc2023-10166): An introductory session on Macros, their roles, and workings with a basic example.
 - [Expand Swift Macros](https://developer.apple.com/videos/play/wwdc2023-10167): A deeper exploration into crafting your Macros and testing their functionality.
-- [Example Swift Macros](https://github.com/DougGregor/swift-macro-examples): Check out real-world examples from Apple, like `@AddCompletionHandler` and `@AddAsync`.
 
-### **The Swift Programming Language (5.9 beta):**
+Other Apple Resources:
+
 - [Macros](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/macros): The Official Step-by-Step Guide to Using Macros for Compile-Time Code Generation in Swift.
+- [Example Swift Macros](https://github.com/DougGregor/swift-macro-examples): Check out real-world examples from Apple, like `@AddCompletionHandler` and `@AddAsync`.
 
 ### **Community Blogs**
 - [Swift Macros by SwiftLee](https://www.avanderlee.com/swift/macros/)


### PR DESCRIPTION
Hello, thank you for maintaining this valuable repository. I would like to propose an addition to the Learning Resources section.

In this PR, I've included a link to the Swift Programming Language (5.9 beta) official guidelines by Apple. This particular resource:

[Macros](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/macros): Provides an official step-by-step guide to using macros for compile-time code generation in Swift.

I believe this addition will be beneficial to users, as it provides a deep dive into an important aspect of Swift development. Please let me know if there are any issues or further improvements I could make.

Looking forward to your feedback.