### PR TITLE
Add `AssociatedObject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ that implements the same interface as the protocol and keeps track of interactio
 ### Enums
 - [ExtractCaseValue](https://github.com/fruitcoder/extract-case-value): A Swift macro that extracts associated values from enum cases.
 
+### Utility
+- [AssociatedObject](https://github.com/p-x9/AssociatedObject): A Swift Macro for adding stored properties in Extension to classes defined in external modules, etc.  
+  (This is implemented by wrapping `objc_getAssociatedObject`/`objc_setAssociatedObject`.)
+
 ### Misc
 - [MacroKit](https://github.com/IanKeen/MacroKit): A collection of macros including:
   - `@PublicInit`: Generate public memberwise init

--- a/README.md
+++ b/README.md
@@ -60,10 +60,6 @@ that implements the same interface as the protocol and keeps track of interactio
 ### Enums
 - [ExtractCaseValue](https://github.com/fruitcoder/extract-case-value): A Swift macro that extracts associated values from enum cases.
 
-### Utility
-- [AssociatedObject](https://github.com/p-x9/AssociatedObject): A Swift Macro for adding stored properties in Extension to classes defined in external modules, etc.  
-  (This is implemented by wrapping `objc_getAssociatedObject`/`objc_setAssociatedObject`.)
-
 ### Misc
 - [MacroKit](https://github.com/IanKeen/MacroKit): A collection of macros including:
   - `@PublicInit`: Generate public memberwise init
@@ -72,6 +68,8 @@ that implements the same interface as the protocol and keeps track of interactio
   - `@StaticMemberIterable`: Like `CaseIterable` but for available static members on a type
   - More to come...
 - [InitMacro](https://github.com/LeonardoCardoso/InitMacro): A Swift Macro implementation that generates initializers for classes and structs with support for default values, wildcards and access control.
+- [AssociatedObject](https://github.com/p-x9/AssociatedObject): A Swift Macro for adding stored properties in Extension to classes defined in external modules, etc.  
+  (This is implemented by wrapping `objc_getAssociatedObject`/`objc_setAssociatedObject`.)
 ---
 
 _**Take part in this exciting evolution in Swift. Your contributions are most welcome!**_


### PR DESCRIPTION
https://github.com/p-x9/AssociatedObject

Swift Macro for adding stored properties in Extension to classes defined in external modules, etc.

For example, you can add a new stored property to `UIViewController` by declaring the following

```swift
import AssociatedObject

extension UIViewController {
    @AssociatedObject(.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
    var text = "text"
}
```

At this time, the following can be used

```swift
class ViewController: UIViewController {
    override func viewDidLoad() {
        super.viewDidLoad()

        print(text) // => "text"

        text = "hello"
        print(text) // => "hello"
    }

}
```