### PR TITLE
Suggestion: Alternate Approach to CodingKeys Creation with Custom Mapping Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Other Apple Resources:
 
 ### Models
 - [Coding Keys](https://github.com/Ryu0118/CodingKeysMacro): Effortlessly generate CodingKeys for converting `snake_case` to `lowerCamelCase`.
+- [Coding Keys](https://github.com/sasha-riabchuk/CodingKeysMacro-swift): A Swift Macro for automating CodingKeys creation in Codable structs. Supports custom string mappings for properties.
 - [Builder pattern](https://github.com/dziobaczy/SwiftBuilderMacro): Apply the [Builder Pattern](https://refactoring.guru/design-patterns/builder) with ease by generating a `Builder` helper class, mimicking stored properties of the associated struct.
 - [EnhancedMirror](https://github.com/unixzii/EnhancedMirror): An experimental Mirror alternative that utilizes Swift Macros for static reflection.
 


### PR DESCRIPTION
This Pull Request introduces a new way for creating `CodingKeys` with the support for custom mapping of property names. 

Key changes:
- A new Swift Macro, `@CodingKeysMacro<Type>`, has been introduced to automate the creation of `CodingKeys`.
- The Macro supports custom string mappings for properties which is achieved through an optional dictionary parameter.
- The Macro is capable of handling both the default and custom scenarios, thus preserving the original behavior while providing enhanced functionality.

## Custom Mapping

Using this library is super simple. Here's an example with custom mapping:

```swift

@CodingKeysMacro<Address>([
    \.buildingNumber: "building_number"
])
struct Address: Codable {
    var buildingNumber: String
    let city: String
    let cityPart: String
    let district: String
    let country: String
    let registryBuildingNumber: String?
    let street: String
    let zipCode: String
}

```
The example above will generate the following `CodingKeys`:

```swift

enum CodingKeys: String, CodingKey {
    case buildingNumber = "building_number"
    case city
    case cityPart
    case district
    case country
    case registryBuildingNumber
    case street
    case zipCode
}

```

## Without mapping

Using this library is super simple. Here's an example with custom mapping:

```swift

@CodingKeysMacro<Address>()
struct Address: Codable {
    var buildingNumber: String
    let city: String
    let cityPart: String
    let district: String
    let country: String
    let registryBuildingNumber: String?
    let street: String
    let zipCode: String
}

```
The example above will generate the following `CodingKeys`:

```swift

enum CodingKeys: String, CodingKey {
    case buildingNumber
    case city
    case cityPart
    case district
    case country
    case registryBuildingNumber
    case street
    case zipCode
}

```