### PR TITLE
Add Sealed Macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Other Apple Resources:
   - Allows to provide default value **in case of decoding failures**.
   - Generates member-wise initializer **considering the default values**.
   - Allows to create custom decoding/encoding strategies. 
+- [Sealed](https://github.com/leedh2004/SealedMacro): Parsing easily Sealed Class JSON Model on Server. (ex. kotlin server)
 
 ### Testing
 - [Power Assert](https://github.com/kishikawakatsumi/swift-power-assert): Adds assertions that can automatically produce information about the values being evaluated, and present it in an easily digestible form.


### PR DESCRIPTION
Parsing easily Sealed Class JSON model on Server (ex. kotlin server's sealed class json)

###  At a Glance
Server's Sealed Class JSON Response
```json
{
  "_type": "IMAGE",
  "imageURL": "https://github.com/images",
  "imageName": "source"
}
```
```json
{
  "_type": "LOTTIE",
  "lottieURL": "https://github.com/lotties"
}
```
```json
{
  "_type": "ICON_TYPE",
  "iconURL": "https://github.com/icons"
}
```
This is can parse with this Swift Model:

```swift
@Sealed(typeKey: "_type", typeParseRule: .upperSnakeCase)
enum ImageSource {
    case image(Image)
    case lottie(Lottie)
    case iconType(Icon)
}

extension ImageSource { 
  struct Image: Codable {
    var imageURL: String
    var imageName: String
  }

  struct Lottie: Codable {
    var lottieURL: String
  }

  struct Icon: Codable {
    var iconURL: String
  }
}
```

Test Code
```swift
let json = """
        {
            "type": "LOTTIE",
            "lottieURL": "https://github.com/images"
        }
        """
let jsonData = Data(json.utf8)
let imageSource = try? decoder.decode(ImageSource.self, from: jsonData)
XCTAssertTrue(imageSource != nil)
```

Thanks you!