### PR TITLE
Add ModifiedCopyMacro

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ that implements the same interface as the protocol and keeps track of interactio
   - `@ReturnType`: Constructs a type consisting of the return type of function.
 - [Reuse Identifier](https://github.com/collisionspace/ReuseIdentifierMacro): A Reuse Identifier Macro that is useful in generation of a reuse id for your UICollectionViewCells and UITableViewCells
 - [SwiftMacros collection](https://github.com/ShenghaiWang/SwiftMacros): A practical collection of Swift Macros that help code correctly and smartly.
+- [ModifiedCopyMacro](https://github.com/WilhelmOks/ModifiedCopyMacro): A Swift macro for making inline copies of a struct by modifying a property. 
 ---
 
 _**Take part in this exciting evolution in Swift. Your contributions are most welcome!**_


### PR DESCRIPTION
https://github.com/WilhelmOks/ModifiedCopyMacro

A Swift macro for making inline copies of a struct by modifying a property. 

Example:

```
@Copyable
struct Person {
    let name: String
    var age: Int
}
```
Expands into:
```
struct Person {
    let name: String
    var age: Int

    /// Returns a copy of the caller whose value for `name` is different.
    func copy(name: String) -> Self {
        .init(name: name, age: age)
    }
    
    /// Returns a copy of the caller whose value for `age` is different.
    func copy(age: Int) -> Self {
        .init(name: name, age: age)
    }
}
```