### PR TITLE
Add `DictionaryLiteralShorthandMacro`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ that implements the same interface as the protocol and keeps track of interactio
   - `@ReturnType`: Constructs a type consisting of the return type of function.
 - [Reuse Identifier](https://github.com/collisionspace/ReuseIdentifierMacro): A Reuse Identifier Macro that is useful in generation of a reuse id for your UICollectionViewCells and UITableViewCells
 - [SwiftMacros collection](https://github.com/ShenghaiWang/SwiftMacros): A practical collection of Swift Macros that help code correctly and smartly.
-- [ModifiedCopyMacro](https://github.com/WilhelmOks/ModifiedCopyMacro): A Swift macro for making inline copies of a struct by modifying a property. 
+- [ModifiedCopyMacro](https://github.com/WilhelmOks/ModifiedCopyMacro): A Swift macro for making inline copies of a struct by modifying a property.
+- [DictionaryLiteralShorthandMacro](https://github.com/Dcard/DictionaryLiteralShorthandMacro): A Swfit macro for creating dictionary literals with keys as "string representations of corresponding variable names".
 ---
 
 _**Take part in this exciting evolution in Swift. Your contributions are most welcome!**_


### PR DESCRIPTION
# DictionaryLiteralShorthand

`DictionaryLiteralShorthand` is a Swift compiler plugin that provides a [macro](https://developer.apple.com/videos/play/wwdc2023/10166/) for creating dictionary literals with keys as string representations of corresponding variable names. 

It simplifies the process of creating dictionaries by automatically generating the keys based on variable names. 

This macro is inspired by the [shorthand syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) for object initializers in JavaScript.

UIKit also offers a similar macro called [NSDictionaryOfVariableBindings](https://developer.apple.com/documentation/uikit/nsdictionaryofvariablebindings) for NSDictionary.


# Usage
In the past, if you want to define a dictionary with the key is the same as the variable name, you write: 

```
let a = 99
let b = "foo"
let dictionary: [AnyHashable: Any] = ["a": a, "b": b]
```

With this macro, you simply write

```
import DictionaryLiteralShorthand

let a = 99
let b = "foo"
let dictionary: [AnyHashable: Any] = #dictionaryLiteralShorthand(a, b)

// This is the equalivant code generated by the compiler:
// let dictionary: [AnyHashable: Any] = ["a": a, "b": b]
```
The compiler magically "exapnds" the macro for you, saving your time from writing boilerplate code.

Note: 

* The shorthand accepts only "variable names", do not input "literals" such as a String literal, or an Integer literal

```
/// ❌ This raises a compiler error, as we don't have a "variable name" to input to dictionary
let dictionary: [AnyHashable: Any] = #dictionaryLiteralShorthand(["Foo", 999])
```