### PR TITLE
add TemporaryVariable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ that implements the same interface as the protocol and keeps track of interactio
 - [SwiftMacros collection](https://github.com/ShenghaiWang/SwiftMacros): A practical collection of Swift Macros that help code correctly and smartly.
 - [ModifiedCopyMacro](https://github.com/WilhelmOks/ModifiedCopyMacro): A Swift macro for making inline copies of a struct by modifying a property.
 - [DictionaryLiteralShorthandMacro](https://github.com/Dcard/DictionaryLiteralShorthandMacro): A Swfit macro for creating dictionary literals with keys as "string representations of corresponding variable names".
+- [TemporaryVariable](https://github.com/yume190/TemporaryVariable): `TemporaryVariable` provide a macro `#info {...}`. It capture most function calls and assign them to temporary variables.
 ---
 
 _**Take part in this exciting evolution in Swift. Your contributions are most welcome!**_


### PR DESCRIPTION
# TemporaryVariable

---

`TemporaryVariable` provide a macro `#info {...}`. It capture most function calls and assign them to temporary variables.

### Usage

Most of the time we will write the following code.

```swift
func test() -> Int {
    return x()
}
```

Usually we need a temporary variable to facilitate our debugging

```swift
func test() -> Int {
    let result = x()
    return result
}
```

Now. You can use `#info {...}`

```swift
import TemporaryVariable
func test() -> Int {
    #info {
        return x()
    }
}
```

The expanded code

```swift
import TemporaryVariable
func test() -> Int {
    let __macro_local_7result0fMu_ = x()
    return __macro_local_7result0fMu_
}
```
