### PR TITLE
Add StructBuilderMacro link

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Other Apple Resources:
 - [Coding Keys](https://github.com/sasha-riabchuk/CodingKeysMacro-swift): A Swift Macro for automating CodingKeys creation in Codable structs. Supports custom string mappings for properties.
 - [Coding Keys](https://github.com/zijievv/CodingKeysGenerator): Swift macros generating customizable `CodingKeys`.
 - [Builder pattern](https://github.com/dziobaczy/SwiftBuilderMacro): Apply the [Builder Pattern](https://refactoring.guru/design-patterns/builder) with ease by generating a `Builder` helper class, mimicking stored properties of the associated struct.
+- [Struct Builder Macro](https://github.com/alschmut/StructBuilderMacro): An attached macro that produces a peer struct which implements the builder pattern. This allows the creation of the struct with minimal effort using default values.
 - [EnhancedMirror](https://github.com/unixzii/EnhancedMirror): An experimental Mirror alternative that utilizes Swift Macros for static reflection.
 - [MetaCodable](https://github.com/SwiftyLab/MetaCodable): Generates `Codable` implementation with following features:
   - Allows custom `CodingKey` value declaration per variable, instead of requiring you to write for all fields.


### PR DESCRIPTION
# Add StructBuilderMacro link
[StructBuilderMacro](https://github.com/alschmut/StructBuilderMacro) is an attached macro that produces a peer struct which implements the builder pattern.
This allows the creation of the struct with minimal effort using default values.

### Example
```swift
@Buildable
struct Person {
    let name: String
    let age: Int
    let address: Address
    let hobby: String?
    
    var likesReading: Bool {
        hobby == "Reading" 
    }
    
    static let minimumAge = 21
}

let anyPerson = PersonBuilder().build()
let max = PersonBuilder(name: "Max").build()
```
Expanded macro
```swift
struct PersonBuilder {
    var name: String = ""
    var age: Int = 0
    var address: Address = AddressBuilder().build()
    var hobby: String?

    func build() -> Person {
        return Person(
            name: name,
            age: age,
            address: address,
            hobby: hobby
        )
    }
}
```