### PR TITLE
Add swift-macro-testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ A lot of use-cases my [Sourcery](https://github.com/krzysztofzablocki/Sourcery) 
 - [Swift AST Explorer](https://swift-ast-explorer.com/)
   - This is extremely helpful when working with [SwiftSyntax](https://github.com/apple/swift-syntax), I used this when writing [Sourcery](https://github.com/krzysztofzablocki/Sourcery) parser and you can leverage it to build your own Macros. 
 
+### **Frameworks**
+
+- [Swift Macro Testing](https://github.com/pointfreeco/swift-macro-testing): Magical testing tools for Swift macros.
+  - Provides `assertMacro`, an alternative to Apple's `assertMacroExpansion` that automatically snapshots macro expansions.
+  - Also provides string-based matching for diagnostics and fix-its instead of manually specifying line and column numbers.
+
 ### **Apple:**
 
 Dive into Swift Macros with these WWDC sessions:
@@ -112,14 +118,6 @@ that implements the same interface as the protocol and keeps track of interactio
 - [TemporaryVariable](https://github.com/yume190/TemporaryVariable): `TemporaryVariable` provide a macro `#info {...}`. It capture most function calls and assign them to temporary variables.
 - [Localizable](https://github.com/ADiks09/Localizable): `Localizable` A macro that produces variables and methods, for your localization files. From the enumeration keys.
 - [SafeDecoding](https://github.com/renato-iar/SafeDecoding): `SafeDecoding` A macro that implements failable decoding via custom initializer; allows auto-conformance to `Decodable`` and per-property opt-out.
-
-## Macro Development Helpers :hammer:
-
-### Testing Macros
-
-- [Swift Macro Testing](https://github.com/pointfreeco/swift-macro-testing): Magical testing tools for Swift macros.
-  - Provides `assertMacro`, an alternative to Apple's `assertMacroExpansion` that automatically snapshots macro expansions.
-  - Also provides string-based matching for diagnostics and fix-its instead of manually specifying line and column numbers.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,15 @@ that implements the same interface as the protocol and keeps track of interactio
 - [TemporaryVariable](https://github.com/yume190/TemporaryVariable): `TemporaryVariable` provide a macro `#info {...}`. It capture most function calls and assign them to temporary variables.
 - [Localizable](https://github.com/ADiks09/Localizable): `Localizable` A macro that produces variables and methods, for your localization files. From the enumeration keys.
 - [SafeDecoding](https://github.com/renato-iar/SafeDecoding): `SafeDecoding` A macro that implements failable decoding via custom initializer; allows auto-conformance to `Decodable`` and per-property opt-out.
+
+## Macro Development Helpers :hammer:
+
+### Testing Macros
+
+- [Swift Macro Testing](https://github.com/pointfreeco/swift-macro-testing): Magical testing tools for Swift macros.
+  - Provides `assertMacro`, an alternative to Apple's `assertMacroExpansion` that automatically snapshots macro expansions.
+  - Also provides string-based matching for diagnostics and fix-its instead of manually specifying line and column numbers.
+
 ---
 
 _**Take part in this exciting evolution in Swift. Your contributions are most welcome!**_


### PR DESCRIPTION
This adds pointfree's swift-macro-testing library. I created a new section called "Macro Development Helpers", since this library doesn't actually provide any macros itself but is useful for developing and testing macros.