### PR TITLE
Add TranslateKit SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ that implements the same interface as the protocol and keeps track of interactio
 - [TemporaryVariable](https://github.com/yume190/TemporaryVariable): `TemporaryVariable` provide a macro `#info {...}`. It capture most function calls and assign them to temporary variables.
 - [Localizable](https://github.com/ADiks09/Localizable): `Localizable` A macro that produces variables and methods, for your localization files. From the enumeration keys.
 - [Localize](https://github.com/Mackarous/Localize): `#Localize` An inline (freestanding) macro that expands to `LocalizedStringResource` and works within Swift packages.
+- [TranslateKit SDK](https://github.com/FlineDev/TranslateKit): A Swift localization framework that simplifies app translation with macros and pre-localized strings.
+  - `#tk("Save Changes")` automatically generates a **semantic localization key** instead of hardcoding strings.
+  - **2000+ pre-localized strings** in ~40 languages, covering common UI text without adding them to a String Catalog.
+  - **Autocompletion support** in Xcode makes discovering the right translation easy.
+  - **Category-specific extensions** for App Store app types (Finance, Health, Productivity, etc.).
+  - **Supports Swift Packages** with `#tkm`, ensuring correct key resolution inside SPM modules.
 - [SafeDecoding](https://github.com/renato-iar/SafeDecoding): `SafeDecoding` A macro that implements failable decoding via custom initializer; allows auto-conformance to `Decodable`` and per-property opt-out.
 - [ObfuscateMacro](https://github.com/p-x9/ObfuscateMacro): A macro for obfuscating strings and make them harder to find by binary analysis.
 - [MemoizeMacro](https://github.com/tornikegomareli/MemoizeMacro?tab=readme-ov-file): A macro for effortless function memoization in Swift


### PR DESCRIPTION
I just released [TranslateKit SDK](https://github.com/FlineDev/TranslateKit) with a localization macro. So I placed it below the other localization macros.